### PR TITLE
Add new commands for tx error monitor

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -1014,6 +1014,27 @@ def load_minigraph(no_service_restart):
         _restart_services()
     click.echo("Please note setting loaded from minigraph will be lost after system reboot. To preserve setting, run `config save`.")
 
+def is_valid_tx_error_monitor(value):
+    if value.isnumeric() == False or value < 0:
+        return False
+    return True
+
+@config.command("tx_error_monitor")
+@click.argument('param', required=True)
+@click.argument('value', required=True)
+def tx_error_monitor_set(param, value):
+    if param.lower() != 'threshold' and param.lower() != 'polling_period':
+        click.echo("Valid arguments are threshold or polling_period")
+        return
+    if not is_valid_tx_error_monitor(value):
+        click.echo('Configured value must be a positive number')
+        return
+
+    table_name = "TX_ERROR_CFG"
+    config_db = ConfigDBConnector()
+    config_db.connect()
+    click.echo(param)
+    config_db.set_entry(table_name, param, {"value":value})
 
 #
 # 'hostname' command

--- a/show/main.py
+++ b/show/main.py
@@ -847,6 +847,51 @@ def status(interfacename, namespace, display, verbose):
     run_command(cmd, display_cmd=verbose)
 
 
+@cli.group(cls=AliasedGroup, default_if_no_args=False)
+def tx_error_monitor():
+    pass
+
+# show tx_error_monitor configuration
+@tx_error_monitor.command()
+def config():
+    """show tx error monitor configuration"""
+    config_db = ConfigDBConnector()
+    config_db.connect()
+    data = config_db.get_table('TX_ERROR_CFG')
+
+    for param in data:
+        value = data[param]['value']
+        if param.lower().endswith('period'):
+            conf = 'polling_period'
+        else:
+            conf = 'threshold'
+
+        click.echo('%s value is %s' % (conf, value))
+
+#show tx_error_monitor state
+@tx_error_monitor.command()
+def state():
+    """show tx error monitor ports states"""
+    db = SonicV2Connector(host='127.0.0.1')
+    db.connect(db.STATE_DB, False) # make only one attempt
+    statedb_perfix = 'TX_ERROR_STATE_TABLE|'
+    _hash = '{}{}'.format(statedb_perfix, '*')
+    statedb_keys = db.keys(db.STATE_DB, _hash)
+
+    state_list = []
+    for key in sorted(statedb_keys):
+        curr_state = db.get(db.STATE_DB, key, 'port_state')
+        if key.startswith(statedb_perfix):
+            key = key[len(statedb_perfix):]
+        state_list.append([key, curr_state])
+
+    header = ['Port', 'State']
+    if not state_list:
+        click.echo("State list is empty.")
+    else:
+        click.echo(tabulate(state_list, headers=header))
+
+
 # 'counters' subcommand ("show interfaces counters")
 @interfaces.group(invoke_without_command=True)
 @click.option('-a', '--printall', is_flag=True)


### PR DESCRIPTION
Signed-off-by: liora <liora@nvidia.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged.

If you are adding/modifying/removing any command or utility script, please also
make sure to add/modify/remove any unit tests from the tests
directory as appropriate.

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->

**- What I did**
Add 2 new commands:
1. Configure TX error monitor threshold and polling period.
2. Show command to see the above configuration.

**- How I did it**

**- How to verify it**

**- Previous command output (if the output of a command-line utility has changed)**

**- New command output (if the output of a command-line utility has changed)**
$ sudo show tx_error_monitor config
threshold value is 100
polling_period value is 20

