### PR TITLE
[show] Allow system with no ports in config db run without errors

### DIFF
--- a/utilities_common/cli.py
+++ b/utilities_common/cli.py
@@ -125,8 +125,7 @@ class InterfaceAliasConverter(object):
             self.port_dict = self.config_db.get_table('PORT')
         self.alias_max_length = 0
 
-
-        if not self.port_dict:
+        if self.port_dict is None:
             click.echo(message="Warning: failed to retrieve PORT table from ConfigDB!", err=True)
             self.port_dict = {}
 


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

**What I did**
Allow system with no ports in config db run without errors.
This is needed for modular system which should boot properly without line cards.

**How I did it**
Do not raise warning in ports dictionary is empty.

**How to verify it**
Run show interfaces status

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

