### PR TITLE
Add support for IP interface loopback action

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -4685,6 +4685,34 @@ def unbind(ctx, interface_name):
         remove_router_interface_ip_address(config_db, interface_name, ipaddress)
     config_db.set_entry(table_name, interface_name, None)
 
+#
+# 'config interface loopback-action <interface-name> <action>'
+#
+
+@interface.command()
+@click.argument('interface_name', metavar='<interface_name>', required=True)
+@click.argument('action', metavar='<action>', required=True)
+@click.pass_context
+def loopback_action(ctx, interface_name, action):
+    """Set IP interface loopback action"""
+    config_db = ctx.obj['config_db']
+
+    if clicommon.get_interface_naming_mode() == "alias":
+        interface_name = interface_alias_to_name(config_db, interface_name)
+        if interface_name is None:
+            ctx.fail('Interface {} is invalid'.format(interface_name))
+
+    if not clicommon.is_interface_in_config_db(config_db, interface_name):
+        ctx.fail('Interface {} is not an IP interface'.format(interface_name))
+
+    allowed_actions = ['drop', 'forward']
+    if action not in allowed_actions:
+        ctx.fail('Invalid action')
+
+    table_name = get_interface_table_name(interface_name)
+    if not table_name:
+        ctx.fail('Interface {} is invalid'.format(interface_name))
+    config_db.set_entry(table_name, interface_name, {"loopback_action": action})
 
 #
 # 'ipv6' subgroup ('config interface ipv6 ...')

--- a/tests/loopback_action_test.py
+++ b/tests/loopback_action_test.py
@@ -10,7 +10,7 @@ Interface        Action
 Eth32.10         drop
 Ethernet0        forward
 PortChannel0001  drop
-Vlan2000         forward
+Vlan3000         forward
 """
 
 class TestLoopbackAction(object):
@@ -25,6 +25,7 @@ class TestLoopbackAction(object):
         obj = {'config_db':db.cfgdb}
         action = 'drop'
         iface = 'Ethernet0'
+
         result = runner.invoke(config.config.commands['interface'].commands['loopback-action'], [iface, action], obj=obj)
     
         table = db.cfgdb.get_table('INTERFACE')
@@ -39,6 +40,7 @@ class TestLoopbackAction(object):
         obj = {'config_db':db.cfgdb}
         action = 'forward'
         iface = 'PortChannel0002'
+
         result = runner.invoke(config.config.commands['interface'].commands['loopback-action'], [iface, action], obj=obj)
     
         table = db.cfgdb.get_table('PORTCHANNEL_INTERFACE')
@@ -53,6 +55,7 @@ class TestLoopbackAction(object):
         obj = {'config_db':db.cfgdb}
         action = 'drop'
         iface = 'Vlan1000'
+
         result = runner.invoke(config.config.commands['interface'].commands['loopback-action'], [iface, action], obj=obj)
     
         table = db.cfgdb.get_table('VLAN_INTERFACE')
@@ -67,6 +70,7 @@ class TestLoopbackAction(object):
         obj = {'config_db':db.cfgdb}
         action = 'forward'
         iface = 'Ethernet0.10'
+
         result = runner.invoke(config.config.commands['interface'].commands['loopback-action'], [iface, action], obj=obj)
     
         table = db.cfgdb.get_table('VLAN_SUB_INTERFACE')
@@ -90,6 +94,7 @@ class TestLoopbackAction(object):
         action = 'forward'
         iface = 'Ethernet0.11'
         ERROR_MSG = "Error: Interface {} is not an IP interface".format(iface)
+
         result = runner.invoke(config.config.commands['interface'].commands['loopback-action'], [iface, action], obj=obj)
     
         print(result.exit_code, result.output)
@@ -103,6 +108,7 @@ class TestLoopbackAction(object):
         action = 'xforwardx'
         iface = 'Ethernet0'
         ERROR_MSG = "Error: Invalid action"
+
         result = runner.invoke(config.config.commands['interface'].commands['loopback-action'], [iface, action], obj=obj)
     
         print(result.exit_code, result.output)

--- a/tests/loopback_action_test.py
+++ b/tests/loopback_action_test.py
@@ -1,0 +1,115 @@
+import os
+from click.testing import CliRunner
+import config.main as config
+import show.main as show
+from utilities_common.db import Db
+
+show_ip_interfaces_loopback_action_output="""\
+Interface        Action
+---------------  --------
+Eth32.10         drop
+Ethernet0        forward
+PortChannel0001  drop
+Vlan2000         forward
+"""
+
+class TestLoopbackAction(object):
+    @classmethod
+    def setup_class(cls):
+        print("\nSETUP")
+        os.environ['UTILITIES_UNIT_TESTING'] = "1"
+
+    def test_config_loopback_action_on_physical_interface(self):        
+        runner = CliRunner()
+        db = Db()
+        obj = {'config_db':db.cfgdb}
+        action = 'drop'
+        iface = 'Ethernet0'
+        result = runner.invoke(config.config.commands['interface'].commands['loopback-action'], [iface, action], obj=obj)
+    
+        table = db.cfgdb.get_table('INTERFACE')
+        assert(table[iface]['loopback_action'] == action)
+        
+        print(result.exit_code, result.output)
+        assert result.exit_code == 0
+        
+    def test_config_loopback_action_on_port_channel_interface(self):        
+        runner = CliRunner()
+        db = Db()
+        obj = {'config_db':db.cfgdb}
+        action = 'forward'
+        iface = 'PortChannel0002'
+        result = runner.invoke(config.config.commands['interface'].commands['loopback-action'], [iface, action], obj=obj)
+    
+        table = db.cfgdb.get_table('PORTCHANNEL_INTERFACE')
+        assert(table[iface]['loopback_action'] == action)
+        
+        print(result.exit_code, result.output)
+        assert result.exit_code == 0
+        
+    def test_config_loopback_action_on_vlan_interface(self):        
+        runner = CliRunner()
+        db = Db()
+        obj = {'config_db':db.cfgdb}
+        action = 'drop'
+        iface = 'Vlan1000'
+        result = runner.invoke(config.config.commands['interface'].commands['loopback-action'], [iface, action], obj=obj)
+    
+        table = db.cfgdb.get_table('VLAN_INTERFACE')
+        assert(table[iface]['loopback_action'] == action)
+        
+        print(result.exit_code, result.output)
+        assert result.exit_code == 0  
+            
+    def test_config_loopback_action_on_subinterface(self):        
+        runner = CliRunner()
+        db = Db()
+        obj = {'config_db':db.cfgdb}
+        action = 'forward'
+        iface = 'Ethernet0.10'
+        result = runner.invoke(config.config.commands['interface'].commands['loopback-action'], [iface, action], obj=obj)
+    
+        table = db.cfgdb.get_table('VLAN_SUB_INTERFACE')
+        assert(table[iface]['loopback_action'] == action)
+        
+        print(result.exit_code, result.output)
+        assert result.exit_code == 0
+        
+    def test_show_ip_interfaces_loopback_action(self):
+        runner = CliRunner()
+        result = runner.invoke(show.cli.commands["ip"].commands["interfaces"].commands["loopback-action"], [])
+        
+        print(result.exit_code, result.output)
+        assert result.exit_code == 0
+        assert result.output == show_ip_interfaces_loopback_action_output
+
+    def test_config_loopback_action_on_non_ip_interface(self):        
+        runner = CliRunner()
+        db = Db()
+        obj = {'config_db':db.cfgdb}
+        action = 'forward'
+        iface = 'Ethernet0.11'
+        ERROR_MSG = "Error: Interface {} is not an IP interface".format(iface)
+        result = runner.invoke(config.config.commands['interface'].commands['loopback-action'], [iface, action], obj=obj)
+    
+        print(result.exit_code, result.output)
+        assert result.exit_code != 0
+        assert ERROR_MSG in result.output
+        
+    def test_config_loopback_action_invalid_action(self):        
+        runner = CliRunner()
+        db = Db()
+        obj = {'config_db':db.cfgdb}
+        action = 'xforwardx'
+        iface = 'Ethernet0'
+        ERROR_MSG = "Error: Invalid action"
+        result = runner.invoke(config.config.commands['interface'].commands['loopback-action'], [iface, action], obj=obj)
+    
+        print(result.exit_code, result.output)
+        assert result.exit_code != 0
+        assert ERROR_MSG in result.output
+
+    @classmethod
+    def teardown_class(cls):
+        print("\nTEARDOWN")
+        os.environ['UTILITIES_UNIT_TESTING'] = "0"

--- a/tests/mock_tables/config_db.json
+++ b/tests/mock_tables/config_db.json
@@ -375,6 +375,7 @@
     },
     "VLAN_SUB_INTERFACE|Eth32.10": {
         "admin_status": "up",
+        "loopback_action": "drop",
         "vlan": "100"
     },
     "ACL_RULE|NULL_ROUTE_V4|DEFAULT_RULE": {
@@ -550,7 +551,8 @@
         "NULL": "NULL"
     },
     "VLAN_INTERFACE|Vlan2000": {
-        "proxy_arp": "enabled"
+        "proxy_arp": "enabled",
+        "loopback_action": "forward"
     },
     "VLAN_INTERFACE|Vlan1000|192.168.0.1/21": {
         "NULL": "NULL"
@@ -636,7 +638,8 @@
         "NULL": "NULL"
     },
     "PORTCHANNEL_INTERFACE|PortChannel0001": {
-        "ipv6_use_link_local_only": "disable"
+        "ipv6_use_link_local_only": "disable",
+        "loopback_action": "drop"
     },
     "PORTCHANNEL_INTERFACE|PortChannel0002": {
         "NULL": "NULL"
@@ -672,7 +675,8 @@
         "NULL": "NULL"
     },
     "INTERFACE|Ethernet0": {
-        "ipv6_use_link_local_only": "disable"
+        "ipv6_use_link_local_only": "disable",
+        "loopback_action": "forward"
     },
     "INTERFACE|Ethernet0|14.14.0.1/24": {
         "NULL": "NULL"

--- a/tests/mock_tables/config_db.json
+++ b/tests/mock_tables/config_db.json
@@ -551,7 +551,9 @@
         "NULL": "NULL"
     },
     "VLAN_INTERFACE|Vlan2000": {
-        "proxy_arp": "enabled",
+        "proxy_arp": "enabled"
+    },
+    "VLAN_INTERFACE|Vlan3000": {
         "loopback_action": "forward"
     },
     "VLAN_INTERFACE|Vlan1000|192.168.0.1/21": {

--- a/utilities_common/cli.py
+++ b/utilities_common/cli.py
@@ -593,6 +593,7 @@ def is_interface_in_config_db(config_db, interface_name):
     if (not interface_name in config_db.get_keys('VLAN_INTERFACE') and
         not interface_name in config_db.get_keys('INTERFACE') and
         not interface_name in config_db.get_keys('PORTCHANNEL_INTERFACE') and
+        not interface_name in config_db.get_keys('VLAN_SUB_INTERFACE') and
         not interface_name == 'null'):
             return False
 


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
Add support for IP interface loopback action.

#### How to verify it
New CLI unittests were added.

#### New config command that was added 
config interface loopback-action <intf-name> drop|forward
config interface loopback-action Ethernet0 drop


#### New show command output 
```
root@sonic:~# show ip interfaces loopback-action
Interface     Action      
------------  ----------  
Ethernet232   drop
Vlan100       forward    
```