### PR TITLE
Add CLI command for ECMP calculator

### DIFF
--- a/show/main.py
+++ b/show/main.py
@@ -66,6 +66,8 @@ from . import syslog
 PLATFORM_JSON = 'platform.json'
 HWSKU_JSON = 'hwsku.json'
 PORT_STR = "Ethernet"
+ECMP_CALC = '/usr/bin/ecmp_calc.py'
+CONTAINER_NAME = 'syncd'
 
 VLAN_SUB_INTERFACE_SEPARATOR = '.'
 
@@ -1032,6 +1034,29 @@ def fib(ipaddress, verbose):
     if ipaddress is not None:
         cmd += " -ip {}".format(ipaddress)
     run_command(cmd, display_cmd=verbose)
+
+
+#
+# 'ecmp-egress-port' subcommand ("show ip ecmp-egress-port...")
+#
+
+@ip.command()
+@click.option('--packet', '-p', required=True, help="Json file describing a packet")
+@click.option('--ingress-port', '-i', required=True, help="Ingress port")
+@click.option('--vrf', '-v', required=False, help="VRF name")
+@click.option('--debug', '-d', required=False, is_flag=True, help="Run in debug mode")
+def ecmp_egress_port(packet, ingress_port, vrf, debug):
+    """Show egress port for given packet"""
+    cmd = "docker cp {} {}:/".format(packet, CONTAINER_NAME)
+    run_command(cmd)
+
+    packet = os.path.basename(packet)
+    cmd = "docker exec {} {} --packet {} --interface {}".format(CONTAINER_NAME, ECMP_CALC, packet, ingress_port)
+    if vrf is not None:
+        cmd += " --vrf {}".format(vrf)
+    if debug is True:
+        cmd += " --debug"
+    run_command(cmd, display_cmd=debug)
 
 
 #

--- a/show/main.py
+++ b/show/main.py
@@ -1035,7 +1035,6 @@ def fib(ipaddress, verbose):
         cmd += " -ip {}".format(ipaddress)
     run_command(cmd, display_cmd=verbose)
 
-
 #
 # 'ecmp-egress-port' subcommand ("show ip ecmp-egress-port...")
 #
@@ -1047,9 +1046,18 @@ def fib(ipaddress, verbose):
 @click.option('--debug', '-d', required=False, is_flag=True, help="Run in debug mode")
 def ecmp_egress_port(packet, ingress_port, vrf, debug):
     """Show egress port for given packet"""
+
+    # Check if ECMP calculaor is implemented
+    proc = subprocess.run(['docker', 'exec', '-it', CONTAINER_NAME, 'test', '-f', ECMP_CALC])
+    if proc.returncode != 0:
+        click.echo("ECMP calculator is not available in this image")
+        return
+
+    # Copy packet JSON to syncd
     cmd = "docker cp {} {}:/".format(packet, CONTAINER_NAME)
     run_command(cmd)
 
+    # Call ECMP calculaor
     packet = os.path.basename(packet)
     cmd = "docker exec {} {} --packet {} --interface {}".format(CONTAINER_NAME, ECMP_CALC, packet, ingress_port)
     if vrf is not None:


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
I have added a new CLI command for calling ECMP calculator.

#### How I did it
Add new CLI command. Command handler calls script /usr/bin/ecmp_calc.py

#### How to verify it
Call command and verify its output.
#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)
```
root@sonic:/home/admin# show ip ecmp-egress-port -i Ethernet64 -p /tmp/packet.json
Egress port: Ethernet0
root@sonic:/home/admin# 
```
