### PR TITLE
Remove TODO comment which is no longer relevant

### DIFF
--- a/scripts/fast-reboot
+++ b/scripts/fast-reboot
@@ -727,8 +727,6 @@ for service in ${SERVICES_TO_STOP}; do
             sonic-db-cli FLEX_COUNTER_DB FLUSHDB > /dev/null
         fi
 
-        # TODO: backup_database preserves FDB_TABLE
-        # need to cleanup as well for fastfast boot case
         backup_database
 
     fi


### PR DESCRIPTION
<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did
I removed TODO comment which is no longer relevant.
TODO can be removed as there is no need to delete FDB table. 
Recently fast boot was changed to use this function and in fast boot we don’t want to clean FDB. 
In warmboot we do need to clean FDB, however, it is being performed in a later stage when FDB flush event occurs.

#### How I did it
Remove comment.

#### How to verify it
Remove comment from python module, no functional effect.

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

